### PR TITLE
Proper signature for ndarray and opaque objects

### DIFF
--- a/nanobind_stubgen/NanobindStubsGenerator.py
+++ b/nanobind_stubgen/NanobindStubsGenerator.py
@@ -267,12 +267,10 @@ class StubNanobindFunction(StubRoutine):
         self.signature = initial_fn[0]
         self.doc_str = initial_fn[1]
 
-        self.signature = utils.update_ndarray_signature(self.signature)
-        self.signature = utils.update_opaque_signature(self.signature)
+        self.signature = utils.post_process_signature(self.signature)
 
         for sig, doc in overloads:
-            sig = utils.update_ndarray_signature(sig)
-            sig = utils.update_opaque_signature(sig)
+            sig = utils.post_process_signature(sig)
             self.children.append(StubNanobindOverloadFunction(self.name, self.obj, sig, doc))
 
     def detect_overloads(self):

--- a/nanobind_stubgen/NanobindStubsGenerator.py
+++ b/nanobind_stubgen/NanobindStubsGenerator.py
@@ -271,6 +271,8 @@ class StubNanobindFunction(StubRoutine):
         self.signature = utils.update_opaque_signature(self.signature)
 
         for sig, doc in overloads:
+            sig = utils.update_ndarray_signature(sig)
+            sig = utils.update_opaque_signature(sig)
             self.children.append(StubNanobindOverloadFunction(self.name, self.obj, sig, doc))
 
     def detect_overloads(self):

--- a/nanobind_stubgen/NanobindStubsGenerator.py
+++ b/nanobind_stubgen/NanobindStubsGenerator.py
@@ -267,6 +267,9 @@ class StubNanobindFunction(StubRoutine):
         self.signature = initial_fn[0]
         self.doc_str = initial_fn[1]
 
+        self.signature = utils.update_ndarray_signature(self.signature)
+        self.signature = utils.update_opaque_signature(self.signature)
+
         for sig, doc in overloads:
             self.children.append(StubNanobindOverloadFunction(self.name, self.obj, sig, doc))
 

--- a/nanobind_stubgen/utils.py
+++ b/nanobind_stubgen/utils.py
@@ -2,6 +2,7 @@ import ast
 import keyword
 import logging
 from typing import Tuple, Optional, Any
+import re
 
 
 def is_valid_python(code: str) -> bool:
@@ -11,6 +12,18 @@ def is_valid_python(code: str) -> bool:
         return False
     return True
 
+
+def update_ndarray_signature(signature: str) -> str:
+    # Replace "numpy.ndarray[...]" to "numpy.typing.NDArray"
+    signature = re.sub(
+        r"numpy.ndarray\[.*?\]", "numpy.typing.NDArray", signature
+    )
+    return signature
+
+def update_opaque_signature(signature: str) -> str:
+    # Replace "<$type $object at $address>" to "..."
+    signature = re.sub(r"<.* at 0x[0-9a-f]+>", "...", signature)
+    return signature
 
 def parse_doc_signature(obj: Any, basic_signature: str) -> Tuple[str, Optional[str], Optional[str]]:
     doc = obj.__doc__
@@ -24,6 +37,9 @@ def parse_doc_signature(obj: Any, basic_signature: str) -> Tuple[str, Optional[s
     signature = parts[0]
     doc = "\n".join([p for p in parts[1:] if p.strip() != ""])
     func_name = signature.split("(")[0].strip()
+
+    signature = update_ndarray_signature(signature)
+    signature = update_opaque_signature(signature)
 
     return signature, doc, func_name
 

--- a/nanobind_stubgen/utils.py
+++ b/nanobind_stubgen/utils.py
@@ -20,10 +20,18 @@ def update_ndarray_signature(signature: str) -> str:
     )
     return signature
 
+
 def update_opaque_signature(signature: str) -> str:
     # Replace "<$type $object at $address>" to "..."
     signature = re.sub(r"<.* at 0x[0-9a-f]+>", "...", signature)
     return signature
+
+
+def post_process_signature(signature: str) -> str:
+    signature = update_ndarray_signature(signature)
+    signature = update_opaque_signature(signature)
+    return signature
+
 
 def parse_doc_signature(obj: Any, basic_signature: str) -> Tuple[str, Optional[str], Optional[str]]:
     doc = obj.__doc__
@@ -38,8 +46,7 @@ def parse_doc_signature(obj: Any, basic_signature: str) -> Tuple[str, Optional[s
     doc = "\n".join([p for p in parts[1:] if p.strip() != ""])
     func_name = signature.split("(")[0].strip()
 
-    signature = update_ndarray_signature(signature)
-    signature = update_opaque_signature(signature)
+    signature = post_process_signature(signature)
 
     return signature, doc, func_name
 


### PR DESCRIPTION
This is minor update to handle `nanobind::ndarray` and opaque objects in function signature.