### PR TITLE
Fix docstring indentations & Fix non-str docstring handling & Improve importing

### DIFF
--- a/nanobind_stubgen/utils.py
+++ b/nanobind_stubgen/utils.py
@@ -47,6 +47,11 @@ def update_tensor_signature(signature: str) -> str:
     signature = re.sub(r"tensor\[.*\]", r"numpy.typing.NDArray", signature)
     return signature
 
+def update_list_signature(signature: str) -> str:
+    # Replace "List[*]" with "list"
+    signature = re.sub(r"List\[(.*)]", r"list[\1]", signature)
+    return signature
+
 
 def post_process_signature(signature: str) -> str:
     signature = update_ndarray_signature(signature)
@@ -54,6 +59,7 @@ def post_process_signature(signature: str) -> str:
     signature = update_std_pair_signature(signature)
     signature = update_std_tuple_signature(signature)
     signature = update_tensor_signature(signature)
+    signature = update_list_signature(signature)
     return signature
 
 


### PR DESCRIPTION
## Fix docstring indentations

Consider this docstring:
```
"""
This is a sample docstring.

.. warning::
    This is a sample warning message.
    Sphinx requires this to be indented correctly
"""
```

When parsing this docstring with current version, the result has all indentations removed:
```
"""
This is a sample docstring.

.. warning::
This is a sample warning message.
Sphinx requires this to be indented correctly
"""
```

This PR would remove space in front of lines intelligently

## Add imports based on signatures of module
This PR would add imports based on signatures of module, including `numpy.typing`

## Fix importing `List` in python <3.9
(Originally from: https://github.com/cansik/nanobind-stubgen/issues/5#issuecomment-1732218472)

List is `List[]` instead of `list[]` for python <3.9

This PR would add `from __future__ import annotations` and replace all `List[*]` to `list[*]` in function signatures.

## Fix importing the module itself
(Originally from: https://github.com/cansik/nanobind-stubgen/issues/5#issuecomment-1732218472)

For types that exist in same file (e.g. `_apngasm_python.APNGFrame`), I had to `from . import _apngasm_python` instead of `import _apngasm_python`. For example in `apngasm_python/_apngasm_python/__init__.pyi`:

```python
import _apngasm_python

class APNGAsm:
    """
    Class representing APNG file, storing APNGFrame(s) and other metadata.
    """

    def __init__(self, frames: list[_apngasm_python.APNGFrame]) -> None:
        """
        Construct APNGAsm object from an existing vector of apngasm frames.
        
        :param list[apngasm_python._apngasm_python.APNGFrame] frames: A list of APNGFrame objects.
        """
        ...
```

The `_apngasm_python.APNGFrame` would not be recognized, but changing `import _apngasm_python` to `from . import _apngasm_python` would allow recognition of `_apngasm_python.APNGFrame`

<img width="474" alt="image" src="https://github.com/cansik/nanobind-stubgen/assets/61652821/e470c018-6343-48bb-b083-566984530c22">

<img width="467" alt="image" src="https://github.com/cansik/nanobind-stubgen/assets/61652821/ae573fef-2542-4a40-ac93-c0d3cbd0c9ad">

Not sure if this would break other use cases though, so this PR would change import to this pattern:
```
try:
    from . import _apngasm_python
except (ModuleNotFoundError, ImportError) as e:
    import apngasm_python._apngasm_python
```

## Trying out
You may try by using my project at the `formatting` branch: https://github.com/laggykiller/apngasm-python/tree/formatting

```
git clone --recursive https://github.com/laggykiller/apngasm-python.git
cd apngasm-python
git checkout formatting
pip install .
```

I have also tried on nanogui and seems to be working well.